### PR TITLE
Improve support for zsh and possibly other shells

### DIFF
--- a/tsu
+++ b/tsu
@@ -60,7 +60,7 @@ fi;
 if test -z "$USER_SHELL"; then
   # check if user has set shell
   if test -x "$HOME/.termux/shell" ; then
-    ROOT_SHELL=$HOME/.termux/shell
+    ROOT_SHELL="$(readlink -f -- "$HOME/.termux/shell")"
   # has installed bash?
   elif test -x "$PREFIX/bin/bash" ; then
       ROOT_SHELL="$PREFIX/bin/bash"


### PR DESCRIPTION
tsu invokes the user's selected shell by running the symlink `~/.termux/shell`.
zsh checks the name of the symlink to determine what compatibility mode to use. `shell` causes zsh to start in sh compatibility mode, which is usually not desirable.
Other shells may have similar detection mechanisms in place (bash has one, but it does not trigger on `shell`).
This pull request makes tsu resolve the symlink and invoke the user's selected shell directly. This fixes the issue for zsh and possibly other shells, too.