### PR TITLE
Revert: unset LD_PRELOAD for magisk

### DIFF
--- a/tsu
+++ b/tsu
@@ -124,8 +124,6 @@ if [ -e "/sbin/magisk" ]; then
   for s in '/magisk/.core/bin/su' '/sbin/su'; do
     if [ -e "$s" ]; then
       unset LD_LIBRARY_PATH
-      # Magisk 16.4 removed 64 bit binaries which causes problems on some devices:
-      unset LD_PRELOAD
       SU_BINARY="$s"
     fi
   done


### PR DESCRIPTION
Magisk added back 64-bit binaries in recent versions which are getting enforced.