### PR TITLE
Handle devices running Magisk between 16.4 and 18.2

### DIFF
--- a/tsu
+++ b/tsu
@@ -124,6 +124,11 @@ if [ -e "/sbin/magisk" ]; then
   for s in '/magisk/.core/bin/su' '/sbin/su'; do
     if [ -e "$s" ]; then
       unset LD_LIBRARY_PATH
+      MAG32=$(command su -c "/sbin/magisk -V")
+      if (( "16400" <= "$MAG32"  && "$MAG32" < "18200" )); then
+        # Magisk 16.4-18.2 removed 64 bit binaries which causes problems on some devices:
+        unset LD_PRELOAD
+      fi
       SU_BINARY="$s"
     fi
   done


### PR DESCRIPTION
Still unset the linker preload for these devices.