### PR TITLE
Fix bug in magisk v19.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
 .PHONY: all lint prettify
 
+PREFIX ?= /data/data/com.termux/files/usr/local
+
+all:
+
 lint:
 	./lint.sh
 
 prettify:
 	./prettify.sh
+
+install:
+	mkdir -p $(PREFIX)/bin/
+	install -m700 tsu $(PREFIX)/bin/
+	install -m700 tsudo $(PREFIX)/bin/

--- a/tsu
+++ b/tsu
@@ -142,14 +142,14 @@ else
   done
 fi
 
-if [ -z "$USER_COMMAND" ]; then
-  exec "$SU_BINARY" --preserve-environment -c "HISTFILE=$HOME/.$(basename $ROOT_SHELL)_history_root LD_LIBRARY_PATH=$OLD_LIBRARY_PATH PATH=$PATH $ROOT_SHELL"
+if [ -z "$SU_BINARY" ]; then
+  # we didnt find su binary
+  printf "No superuser binary detected. \\n"
+  printf "Are you rooted? \\n"
+  exit 1
 else
-  exec "$SU_BINARY" --preserve-environment -c "LD_LIBRARY_PATH=$OLD_LIBRARY_PATH PATH=$PATH $USER_COMMAND"
-
+  if [ -z "$USER_COMMAND" ]; then
+    HISTFILE=$HOME/.$(basename $ROOT_SHELL)_history_root LD_LIBRARY_PATH=$OLD_LIBRARY_PATH exec "$SU_BINARY" --preserve-environment -c "$ROOT_SHELL"
+  else
+    LD_LIBRARY_PATH=$OLD_LIBRARY_PATH exec "$SU_BINARY" --preserve-environment -c "$USER_COMMAND"
 fi
-
-# we didnt find su binary
-printf "No superuser binary detected. \\n"
-printf "Are you rooted? \\n"
-exit 1

--- a/tsu
+++ b/tsu
@@ -17,6 +17,8 @@ show_usage() {
   echo '    Append /system/bin:/system/xbin to PATH and /system/lib{64} to LD_LIBRARY_PATH.'
   echo '-e'
   echo '    Setup up some enviroment variables as when in Termux.'
+  echo '-c <command>'
+  echo '    Run given command as root.'
   echo
   echo 'For details of the options see:'
   echo 'https://github.com/cswl/tsu'


### PR DESCRIPTION
Hi, `exec /sbin/su -c "foo=bar bash"` gives a shell that can't be exited for some reason with magisk v19.3, it just hangs.
Using `foo=bar exec /sbin/su -c "bash"` instead seem to work fine.

I've also added a simple install target to the Makefile and added a help message about the `-c` option.