### PR TITLE
Fix -a being ignored

### DIFF
--- a/shell/tsu.sh
+++ b/shell/tsu.sh
@@ -188,7 +188,7 @@ env_path_helper() {
 			log_DEBUG "PREPEND_SYSTEM_PATH"
 			if [[ -n "$PREPEND_SYSTEM_PATH" ]]; then
 				NEW_PATH="$ASP:$NEW_PATH"
-			else
+			elif [[ -n "$APPEND_SYSTEM_PATH" ]]; then
 				NEW_PATH="$NEW_PATH:$ASP"
 			fi
 		fi


### PR DESCRIPTION
I noticed that `$APPEND_SYSTEM_PATH` wasn't consumed anywhere and the Android system path was appended by default. This PR makes the `-a` flag work as described in the help.