### PR TITLE
Preserve PATH and LD_* env vars when invoking sudo -E

### DIFF
--- a/shell/tsu.sh
+++ b/shell/tsu.sh
@@ -276,8 +276,10 @@ else
 fi
 
 # Unset all Termux LD_* enviroment variables to prevent symbols missing , dlopen()ing of wrong libs.
-unset LD_LIBRARY_PATH
-unset LD_PRELOAD
+if [[ -z "$ENVIRONMENT_PRESERVE" ]]; then
+	unset LD_LIBRARY_PATH
+	unset LD_PRELOAD
+fi
 
 ### ----- MAGISKSU
 # shellcheck disable=SC2117
@@ -286,12 +288,11 @@ if [[ -z "$SKIP_SBIN" && "$(/sbin/su -v)" == *"MAGISKSU" ]]; then
 	su_args=("/sbin/su")
 	[[ -z "$SWITCH_USER" ]] || su_args+=("$SWITCH_USER")
 
-	su_cmdline="PATH=$BB_MAGISK "
 	if [[ -n "$ENVIRONMENT_PRESERVE" ]]; then
 		su_args+=("--preserve-environment")
-		su_cmdline+="$STARTUP_SCRIPT"
+		su_cmdline="PATH=$BB_MAGISK:$PATH $STARTUP_SCRIPT"
 	else
-		su_cmdline+="env -i $ENV_BUILT $STARTUP_SCRIPT"
+		su_cmdline="PATH=$BB_MAGISK env -i $ENV_BUILT $STARTUP_SCRIPT"
 	fi
 	su_args+=("-c")
 	exec "${su_args[@]}" "${su_cmdline}"
@@ -305,12 +306,11 @@ else
 			[[ -z "$SWITCH_USER" ]] || su_args+=("$SWITCH_USER")
 
 			# Let's use the system toybox/toolbox for now
-			su_cmdline="PATH=$ANDROID_SYSPATHS "
 			if [[ -n "$ENVIRONMENT_PRESERVE" ]]; then
 				su_args+=("--preserve-environment")
-				su_cmdline+="$STARTUP_SCRIPT "
+				su_cmdline="PATH=$ANDROID_SYSPATHS:$PATH $STARTUP_SCRIPT "
 			else
-				su_cmdline+="env -i $ENV_BUILT $STARTUP_SCRIPT"
+				su_cmdline="PATH=$ANDROID_SYSPATHS env -i $ENV_BUILT $STARTUP_SCRIPT"
 			fi
 			su_args+=("-c")
 			exec "${su_args[@]}" "${su_cmdline}"


### PR DESCRIPTION
Right now `LD_PRELOAD` and `LD_LIBRARY_PATH` get unset when invoking `sudo -E` which should not be the case IMHO. If as a user I want to preserve the env by explicitly specifying `-E` I expect it to preserve it ;)

Unsetting them results in not being able to run scripts whose shebang rely on `LD_PRELOAD` being correctly set.

Also there seems to be an issue with `--preserve-environment`: `PATH` does not currently get preserved.

Example:

**whoami.sh**

```bash
#!/usr/bin/env bash
whoami
```
1. Current behavior

```bash
# Running it normally works
$ ./whoami.sh
u0_a147

# sudoing does not
$ sudo ./whoami.sh
env: can't execute 'whoami.sh': No such file or directory
```


2. What this PR achieves:

```bash
# Running it normally works
$ ./whoami.sh
u0_a147

# sudoing as well \o/
$ sudo ./whoami.sh
root
```