### PR TITLE
Add support for kitsune magisk(R65A24840 or later)

### DIFF
--- a/shell/tsu.sh
+++ b/shell/tsu.sh
@@ -258,7 +258,7 @@ else
 	STARTUP_SCRIPT="$ROOT_SHELL"
 fi
 
-SU_BINARY_SEARCH=("/system/xbin/su" "/system/bin/su" "/su/bin/su" "/apex/com.android.runtime/bin")
+SU_BINARY_SEARCH=("/system/xbin/su" "/system/bin/su" "/su/bin/su" "/apex/com.android.runtime/bin/su")
 
 # On some systems with other root methods `/sbin` is inacessible.
 if [[ -x "/sbin" ]]; then

--- a/shell/tsu.sh
+++ b/shell/tsu.sh
@@ -258,7 +258,7 @@ else
 	STARTUP_SCRIPT="$ROOT_SHELL"
 fi
 
-SU_BINARY_SEARCH=("/system/xbin/su" "/system/bin/su" "/su/bin/su")
+SU_BINARY_SEARCH=("/system/xbin/su" "/system/bin/su" "/su/bin/su" "/apex/com.android.runtime/bin")
 
 # On some systems with other root methods `/sbin` is inacessible.
 if [[ -x "/sbin" ]]; then


### PR DESCRIPTION
Kitsune magisk 26404+ has changed the mounting su location. [see here](https://github.com/HuskyDG/magisk-files/releases/tag/R65A24840-kitsune)  and this will make tsu work again