### PR TITLE
tsu.sh: add new SU_BINARY_SEARCH path

### DIFF
--- a/shell/tsu.sh
+++ b/shell/tsu.sh
@@ -258,7 +258,7 @@ else
 	STARTUP_SCRIPT="$ROOT_SHELL"
 fi
 
-SU_BINARY_SEARCH=("/system/xbin/su" "/system/bin/su" "/su/bin/su")
+SU_BINARY_SEARCH=("/system/xbin/su" "/system/bin/su" "/su/bin/su" "/debug_ramdisk/su")
 
 # On some systems with other root methods `/sbin` is inacessible.
 if [[ -x "/sbin" ]]; then


### PR DESCRIPTION
Added `/debug_ramdisk/su` as a location for a new su executable.

In Magisk Alpha b7ca73f4-alpha 28102, the su executable file no longer exists under /system/bin, so executing tsu will result in failure to obtain root privileges. Adding this path allows tsu to work properly. (Commit msg by alpha devs: `magisk 和 su 等二进制文件不再硬编码于 /system/bin/目录下，而是从 PATH 环境变量中选择第一个可用位置`)

In the original Magisk version 28102, this path also exists and can be used, and therefore it can be considered to have certain universal value.

In the Kitsune Mask, I was unable to test it since my device would not install it (bootloop after install it).